### PR TITLE
Fix for missing help doc verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ files = [
 files = [
     # All machine generated files
     ".gitattributes",
-    "requiements*.txt",
+    "requirements*.txt",
 ]
 # Include all template files above
 include_template_files = true

--- a/src/borg/borg.py
+++ b/src/borg/borg.py
@@ -5,6 +5,7 @@ description:
 example:
     borg compare
     borg update
+    borg generate <FILE>
 """
 
 import argparse


### PR DESCRIPTION
Add `borg generate` to `--help` output.