### PR TITLE
fix: correct typo in .gitattributes (requiements -> requirements)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Ignore files managed by borg in Github PR reviews
 .gitattributes linguist-generated
-requiements*.txt linguist-generated
+requirements*.txt linguist-generated
 .gitignore linguist-generated
 .github/workflows/pr_reminder.yml linguist-generated
 .github/workflows/cleanup.yml linguist-generated


### PR DESCRIPTION
Fixes #19 - Corrected the misspelled word 'requiements' to 'requirements' in .gitattributes line 2.