### PR TITLE
fix: spell requirements correctly in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Ignore files managed by borg in Github PR reviews
 .gitattributes linguist-generated
-requiements*.txt linguist-generated
+requirements*.txt linguist-generated
 .gitignore linguist-generated
 .github/workflows/pr_reminder.yml linguist-generated
 .github/workflows/cleanup.yml linguist-generated

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ will generate this `.gitattributes` file:
 ```sh
 # Ignore files managed by borg in Github PR reviews
 .gitattributes linguist-generated
-requiements*.txt linguist-generated
+requirements*.txt linguist-generated
 .gitignore linguist-generated
 .github/workflows/pr_reminder.yml linguist-generated
 .github/workflows/cleanup.yml linguist-generated


### PR DESCRIPTION
## Summary

Closes #19. `.gitattributes:3` and `README.md:62` both listed the linguist-generated glob as `requiements*.txt` (missing middle `r`), so any file actually named `requirements*.txt` (with the correct spelling) was not matched by the rule. That means the diff-hiding behavior the rule was meant to provide silently no-op'd for the file class it was designed to cover.

The README's example output snippets and the Makefile-style echo on lines 51, 62, and 75 already showed `requirements*.txt` spelled correctly, so the README's example output and the actual rule disagreed with each other. Fix both files.

## Why this matters

The repo is the template-repo-sync tool, which itself documents how to manage `.gitattributes` patterns - so a typo'd pattern in its own `.gitattributes` is a bad reference for downstream users following the README.

## Changes

- `.gitattributes:3` - `requiements*.txt` -> `requirements*.txt`.
- `README.md:62` - same fix; the surrounding example output at `:51, :75` already used the correct spelling, so the README is now internally consistent.

## How to test

```
$ grep -n "requiements" .gitattributes README.md
(empty)
$ grep -n "requirements\*\.txt" .gitattributes README.md
.gitattributes:3:requirements*.txt linguist-generated
README.md:51:    "requirements*.txt",
README.md:62:requirements*.txt linguist-generated
README.md:75:	echo 'requirements*.txt linguist-generated' >> $^  # Add additional files to .gitattributes
```

Fixes #19

AI-assisted.
